### PR TITLE
Fix parsing of axios.post response

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,7 +9,7 @@ import routes from './routes';
  * directly export the Router instantiation
  */
 
-export default route<Store<StateInterface>>(function ({ Vue }) {
+export default route<Store<StateInterface>>(function({ Vue }) {
   Vue.use(VueRouter);
 
   const Router = new VueRouter({
@@ -24,4 +24,4 @@ export default route<Store<StateInterface>>(function ({ Vue }) {
   });
 
   return Router;
-})
+});

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -5,13 +5,12 @@ const routes: RouteConfig[] = [
     path: '/',
     component: () => import('layouts/MainLayout.vue'),
     children: [
-      { path: '', component: () => import('pages/Login.vue') },
+      { path: '', component: () => import('pages/Login.vue') }
       // { path: 'dashboard', component: () => import('pages/Dashboard.vue') },
     ]
   },
 
-  // Always leave this as last one,
-  // but you can also remove it
+  // map all other requests to 404
   {
     path: '*',
     component: () => import('pages/Error404.vue')

--- a/src/store/user/actions.ts
+++ b/src/store/user/actions.ts
@@ -3,6 +3,10 @@ import { StateInterface } from '../index';
 import { UserState } from './state';
 import axios from 'axios';
 
+interface ServerResponse {
+  data: Token;
+}
+
 interface Token {
   id: string;
 }
@@ -14,11 +18,11 @@ const actions: ActionTree<UserState, StateInterface> = {
     params.append('password', password);
     return new Promise((resolve, reject) => {
       axios
-        .post<Token>('/auth/login/', params)
+        .post<ServerResponse>('/auth/login/', params)
         .then(response => {
-          const token = response.data;
-          context.commit('SET_TOKEN', token.id);
-          setAxiosHeaders(token.id);
+          const token = response.data.data.id;
+          context.commit('SET_TOKEN', token);
+          setAxiosHeaders(token);
           resolve();
         })
         .catch(error => {
@@ -30,7 +34,7 @@ const actions: ActionTree<UserState, StateInterface> = {
 
 function setAxiosHeaders(token: string) {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  axios.defaults.headers.common['Authorization'] = 'Basic ' + token;
+  axios.defaults.headers.common['Authorization'] = 'Bearer ' + token;
 }
 
 export default actions;


### PR DESCRIPTION
The response is nested one data deeper.
It nonetheless worked, because django sets a cookie with the response
and then uses that to authenicate the user instead of HTTP auth.